### PR TITLE
Member 도메인 통합 테스트코드 추가 2차

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,3 +99,7 @@ configurations {
     }
     querydsl.extendsFrom compileClasspath
 }
+
+configurations.all {
+    exclude group: 'commons-logging', module: 'commons-logging'
+}

--- a/src/test/java/com/sportsecho/member/MemberIntegrationTest.java
+++ b/src/test/java/com/sportsecho/member/MemberIntegrationTest.java
@@ -2,6 +2,7 @@ package com.sportsecho.member;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -210,6 +211,72 @@ public class MemberIntegrationTest implements MemberTest {
 
             //then
             assertEquals(MemberErrorCode.INVALID_REQUEST, exception.getErrorCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("Member 접근 토큰 재발급 테스트")
+    class MemberRefreshTest {
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        @BeforeEach
+        void MemberRefreshSetUp() {
+            memberService.login(TEST_MEMBER_REQUEST_DTO, response);
+
+            request.addHeader(JwtUtil.REFRESH_AUTHORIZATION_HEADER,
+                Objects.requireNonNull(response.getHeader(JwtUtil.REFRESH_AUTHORIZATION_HEADER)));
+        }
+
+        @Test
+        @DisplayName("Member 접근 토큰 재발급 테스트 성공")
+        void memberRefresh_success() {
+            //given
+
+            //when
+            memberService.refresh(request, response);
+
+            String accessToken = response.getHeader(JwtUtil.AUTHORIZATION_HEADER);
+            String refreshToken = response.getHeader(JwtUtil.REFRESH_AUTHORIZATION_HEADER);
+
+            //then
+            assertNotNull(accessToken);
+            assertNotNull(refreshToken);
+        }
+
+        @Test
+        @DisplayName("Member 접근 토큰 재발급 테스트 실패 - 갱신 토큰이 존재하지 않는 경우")
+        void memberRefresh_fail_refreshTokenNotFound() {
+            //given
+            String refreshToken = request.getHeader(JwtUtil.REFRESH_AUTHORIZATION_HEADER);
+
+            //when
+            redisUtil.removeToken(refreshToken);
+
+            GlobalException exception = assertThrows(GlobalException.class, () ->
+                memberService.refresh(request, response)
+            );
+
+            //then
+            assertEquals(JwtErrorCode.REFRESH_TOKEN_NOT_FOUND, exception.getErrorCode());
+        }
+
+        @Test
+        @DisplayName("Member 접근 토큰 재발급 테스트 실패 - 사용자가 존재하지 않는 경우")
+        void memberRefresh_fail_memberNotFound() {
+            //given
+            String refreshToken = request.getHeader(JwtUtil.REFRESH_AUTHORIZATION_HEADER);
+
+            //when
+            redisUtil.saveRefreshToken(refreshToken, ANOTHER_TEST_EMAIL);
+
+            GlobalException exception = assertThrows(GlobalException.class, () ->
+                memberService.refresh(request, response)
+            );
+
+            //then
+            assertEquals(MemberErrorCode.USER_NOT_FOUND, exception.getErrorCode());
         }
     }
 

--- a/src/test/java/com/sportsecho/member/MemberIntegrationTest.java
+++ b/src/test/java/com/sportsecho/member/MemberIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -12,11 +13,13 @@ import com.sportsecho.common.jwt.exception.JwtErrorCode;
 import com.sportsecho.common.redis.RedisUtil;
 import com.sportsecho.global.exception.GlobalException;
 import com.sportsecho.member.dto.MemberRequestDto;
+import com.sportsecho.member.dto.MemberResponseDto;
 import com.sportsecho.member.entity.Member;
 import com.sportsecho.member.entity.MemberRole;
 import com.sportsecho.member.exception.MemberErrorCode;
 import com.sportsecho.member.repository.MemberRepository;
-import com.sportsecho.member.service.MemberServiceImplV2;
+import com.sportsecho.member.service.MemberService;
+import jakarta.persistence.EntityManager;
 import java.util.Objects;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +28,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -36,7 +40,8 @@ import org.springframework.test.context.ActiveProfiles;
 public class MemberIntegrationTest implements MemberTest {
 
     @Autowired
-    MemberServiceImplV2 memberService;
+    @Qualifier("V2")
+    MemberService memberService;
 
     @Autowired
     MemberRepository memberRepository;
@@ -277,6 +282,23 @@ public class MemberIntegrationTest implements MemberTest {
 
             //then
             assertEquals(MemberErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("Member 회원탈퇴 테스트")
+    class MemberDeleteTest {
+
+        @Test
+        @DisplayName("Member 회원탈퇴 테스트 성공")
+        void memberDelete_success() {
+            //given
+
+            //when
+            MemberResponseDto memberResponseDto = memberService.deleteMember(TEST_MEMBER);
+
+            //then
+            assertEquals(TEST_MEMBER.getEmail(), memberResponseDto.getEmail());
         }
     }
 

--- a/src/test/java/com/sportsecho/member/MemberTestUtil.java
+++ b/src/test/java/com/sportsecho/member/MemberTestUtil.java
@@ -17,12 +17,7 @@ public class MemberTestUtil implements MemberTest {
     }
 
     public static Member getTestMember(String email, String password) {
-        return Member.builder()
-            .memberName(TEST_MEMBER_NAME)
-            .email(email)
-            .password(password)
-            .role(MemberRole.CUSTOMER)
-            .build();
+        return getTestMember(TEST_MEMBER_NAME, email, password, MemberRole.CUSTOMER);
     }
 
     public static MemberRequestDto getTestMemberRequestDto(String memberName, String email, String password) {


### PR DESCRIPTION
## 개요
Member 도메인 통합 테스트코드 추가 2차

## 작업사항
- Member 접근 토큰 재발급 테스트 추가
- Member 회원탈퇴 테스트 추가

## 변경로직

## 관련이슈
Issues #44 