### PR TITLE
Google OAuth 로그인 redirect_uri 변경 및 Cors설정 추가

### DIFF
--- a/src/main/java/com/sportsecho/common/configuration/CorsConfig.java
+++ b/src/main/java/com/sportsecho/common/configuration/CorsConfig.java
@@ -9,7 +9,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedOrigins("http://sportsecho.life");
+            .allowedOrigins("http://sportsecho.life:3000");
     }
 }
 

--- a/src/main/java/com/sportsecho/common/configuration/CorsConfig.java
+++ b/src/main/java/com/sportsecho/common/configuration/CorsConfig.java
@@ -1,0 +1,15 @@
+package com.sportsecho.common.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://sportsecho.life");
+    }
+}
+

--- a/src/main/java/com/sportsecho/common/oauth/OAuthUtil.java
+++ b/src/main/java/com/sportsecho/common/oauth/OAuthUtil.java
@@ -150,7 +150,7 @@ public class OAuthUtil {
             body.add("client_id", googleApiKey);
             body.add("client_secret", googleApiSecret);
             body.add("code", code);
-            body.add("redirect_uri", "http://13.125.46.61:8080/api/members/google/callback");
+            body.add("redirect_uri", "http://ec2-13-125-46-61.ap-northeast-2.compute.amazonaws.com:8080/api/members/google/callback");
         }
 
         return body;


### PR DESCRIPTION
## 개요
Google OAuth 로그인 redirect_uri 변경 및 Cors설정 추가

## 작업사항
- Google RedirectURI EC2 퍼블릭 IP에서 Ipv4 DNS로 변경
- 서비스 도메인 sportsecho.life cors allow 설정 추가

## 변경로직

## 관련이슈