### PR TITLE
purchase toResponseDto mapper로 변경

### DIFF
--- a/src/main/java/com/sportsecho/purchase/dto/PurchaseResponseDto.java
+++ b/src/main/java/com/sportsecho/purchase/dto/PurchaseResponseDto.java
@@ -24,5 +24,5 @@ public class PurchaseResponseDto {
 
     private LocalDateTime purchaseDate;
 
-    private List<PurchaseProductResponseDto> responseDtoList;
+    private List<PurchaseProductResponseDto> purchaseProductList;
 }

--- a/src/main/java/com/sportsecho/purchase/entity/Purchase.java
+++ b/src/main/java/com/sportsecho/purchase/entity/Purchase.java
@@ -2,9 +2,7 @@ package com.sportsecho.purchase.entity;
 
 import com.sportsecho.common.time.TimeStamp;
 import com.sportsecho.member.entity.Member;
-import com.sportsecho.purchase.dto.PurchaseResponseDto;
 import com.sportsecho.purchaseProduct.entity.PurchaseProduct;
-import com.sportsecho.purchaseProduct.mapper.PurchaseProductMapper;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -49,21 +47,5 @@ public class Purchase extends TimeStamp {
 
     public void updateTotalPrice(int totalPrice) {
         this.totalPrice = totalPrice;
-    }
-
-    // 연관 관계가 복잡하여 mapper를 사용하지 않음.. 추후 수정 가능성 있음..
-    public PurchaseResponseDto createResponseDto() {
-        return PurchaseResponseDto.builder()
-            .id(this.id)
-            .totalPrice(this.totalPrice)
-            .address(this.address)
-            .phone(this.phone)
-            .purchaseDate(this.getCreatedAt())
-            .responseDtoList(
-                this.purchaseProductList.stream()
-                    .map(PurchaseProductMapper.INSTANCE::toResponseDto)
-                    .toList()
-            )
-            .build();
     }
 }

--- a/src/main/java/com/sportsecho/purchase/mapper/PurchaseMapper.java
+++ b/src/main/java/com/sportsecho/purchase/mapper/PurchaseMapper.java
@@ -3,9 +3,13 @@ package com.sportsecho.purchase.mapper;
 import com.sportsecho.hotdeal.dto.request.PurchaseHotdealRequestDto;
 import com.sportsecho.member.entity.Member;
 import com.sportsecho.purchase.dto.PurchaseRequestDto;
+import com.sportsecho.purchase.dto.PurchaseResponseDto;
 import com.sportsecho.purchase.entity.Purchase;
+import com.sportsecho.purchaseProduct.mapper.PurchaseProductMapper;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -13,7 +17,8 @@ public interface PurchaseMapper {
 
     PurchaseMapper INSTANCE = Mappers.getMapper(PurchaseMapper.class);
 
-//    PurchaseResponseDto toResponseDto(Purchase purchase);
+    @Mapping(target = "purchaseDate", source = "createdAt")
+    PurchaseResponseDto toResponseDto(Purchase purchase);
 
     @Mapping(target = "totalPrice", constant = "0")
     @Mapping(target = "member", source = "member")
@@ -22,4 +27,15 @@ public interface PurchaseMapper {
     @Mapping(target = "totalPrice", constant = "0")
     @Mapping(target = "member", source = "member")
     Purchase toEntity(PurchaseHotdealRequestDto requestDto, Member member);
+
+    @AfterMapping
+    default void toPurchaseProductList(Purchase purchase,
+        @MappingTarget PurchaseResponseDto.PurchaseResponseDtoBuilder dtoBuilder) {
+
+        dtoBuilder.purchaseProductList(
+            purchase.getPurchaseProductList().stream()
+                .map(PurchaseProductMapper.INSTANCE::toResponseDto)
+                .toList()
+        );
+    }
 }

--- a/src/main/java/com/sportsecho/purchase/repository/PurchaseRepository.java
+++ b/src/main/java/com/sportsecho/purchase/repository/PurchaseRepository.java
@@ -1,10 +1,13 @@
 package com.sportsecho.purchase.repository;
 
 import com.sportsecho.purchase.entity.Purchase;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
 
-    List<Purchase> findByMemberId(Long memberId);
+    @Query("SELECT p FROM Purchase p WHERE p.member.id = :memberId ORDER BY p.createdAt DESC")
+    List<Purchase> findByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/sportsecho/purchase/service/PurchaseServiceImplV1.java
+++ b/src/main/java/com/sportsecho/purchase/service/PurchaseServiceImplV1.java
@@ -59,7 +59,7 @@ public class PurchaseServiceImplV1 implements PurchaseService {
         // 장바구니 비우기
         memberProductRepository.deleteAllByMemberId(member.getId());
 
-        return purchase.createResponseDto();
+        return PurchaseMapper.INSTANCE.toResponseDto(purchase);
     }
 
     @Override
@@ -72,7 +72,7 @@ public class PurchaseServiceImplV1 implements PurchaseService {
         }
 
         return purchaseList.stream()
-            .map(Purchase::createResponseDto)
+            .map(PurchaseMapper.INSTANCE::toResponseDto)
             .toList();
     }
 

--- a/src/test/java/com/sportsecho/purchase/service/PurchaseServiceImplV1Test.java
+++ b/src/test/java/com/sportsecho/purchase/service/PurchaseServiceImplV1Test.java
@@ -95,7 +95,8 @@ class PurchaseServiceImplV1Test implements MemberTest, ProductTest, PurchaseTest
             assertEquals(product.getPrice() * memberProduct.getProductsQuantity(),
                 responseDto.getTotalPrice());
             assertEquals(requestDto.getAddress(), responseDto.getAddress());
-            assertEquals(product.getTitle(), responseDto.getResponseDtoList().get(0).getTitle());
+            assertEquals(product.getTitle(),
+                responseDto.getPurchaseProductList().get(0).getTitle());
             assertTrue(memberProductRepository.findByMemberId(member.getId()).isEmpty());
             assertEquals(productQuantity - memberProduct.getProductsQuantity(),
                 productRepository.findAll().get(0).getQuantity());
@@ -149,9 +150,9 @@ class PurchaseServiceImplV1Test implements MemberTest, ProductTest, PurchaseTest
             assertEquals(memberProduct.getProductsQuantity() * product.getPrice(),
                 responseDtoList.get(0).getTotalPrice());
             assertEquals(product.getTitle(),
-                responseDtoList.get(0).getResponseDtoList().get(0).getTitle());
+                responseDtoList.get(0).getPurchaseProductList().get(0).getTitle());
             assertEquals(memberProduct.getProductsQuantity(),
-                responseDtoList.get(0).getResponseDtoList().get(0).getProductsQuantity());
+                responseDtoList.get(0).getPurchaseProductList().get(0).getProductsQuantity());
         }
 
         @Test


### PR DESCRIPTION
## 개요
createResponseDto() 메서드에서 toResponseDto 매퍼 사용으로 변경

## 작업사항
purchase response dto의 PurchaseProductResponseDtoList 변수명 변경
구매 내역 조회시 구매 시간 내림차순으로 정렬하도록 변경

## 변경로직

## 관련이슈