### PR TITLE
Product Entity OptimisticLock 기능 추가

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -45,26 +45,32 @@ jobs:
           key: ${{ secrets.EC2_KEY }}
 
           script: |
-            sudo docker kill ${{ secrets.PROJECT_NAME }}
-            sudo docker rm -f ${{ secrets.PROJECT_NAME }}
+#           실행중인 서버 다운
+            sudo docker-compose down
+                    
+#           백엔드 도커 이미지 삭제
             sudo docker rmi ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
-            sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.PROJECT_NAME }}
-           
-            sudo docker run \
-            -e ADMIN_SECRET_KEY=${{ secrets.ADMIN_SECRET_KEY }} \
-            -e AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }} \
-            -e AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }} \
-            -e BASEBALL_API_KEY=${{ secrets.BASEBALL_API_KEY }} \
-            -e BASKETBALL_API_KEY=${{ secrets.BASKETBALL_API_KEY }} \
-            -e FOOTBALL_API_KEY=${{ secrets.FOOTBALL_API_KEY }} \
-            -e GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }} \
-            -e GOOGLE_API_SECRET=${{ secrets.GOOGLE_API_SECRET }} \
-            -e JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }} \
-            -e KAKAO_API_KEY=${{ secrets.KAKAO_API_KEY }} \
-            -e NAVER_API_KEY=${{ secrets.NAVER_API_KEY }} \
-            -e NAVER_API_SECRET=${{ secrets.NAVER_API_SECRET }} \
-            -e RDS_USERNAME=${{ secrets.RDS_USERNAME }} \
-            -e RDS_PASSWORD=${{ secrets.RDS_PASSWORD }} \
-            -p ${{ secrets.PORT }}:${{ secrets.PORT }} \
-            --name ${{ secrets.PROJECT_NAME }} \
-            -d ${{ secrets.DOCKERHUB_USERNAME}}/${{ secrets.PROJECT_NAME }}
+                    
+#           백엔드 환경변수 파일 삭제 및 생성
+            sudo rm .env_b
+            sudo touch .env_b
+                    
+#           백엔드 환경변수 파일 작성
+            echo ADMIN_SECRET_KEY=${{ secrets.ADMIN_SECRET_KEY }} >> .env_b
+            echo AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }} >> .env_b
+            echo AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }} >> .env_b
+            echo BASEBALL_API_KEY=${{ secrets.BASEBALL_API_KEY }} >> .env_b
+            echo BASKETBALL_API_KEY=${{ secrets.BASKETBALL_API_KEY }} >> .env_b
+            echo FOOTBALL_API_KEY=${{ secrets.FOOTBALL_API_KEY }} >> .env_b
+            echo GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }} >> .env_b
+            echo GOOGLE_API_SECRET=${{ secrets.GOOGLE_API_SECRET }} >> .env_b
+            echo JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }} >> .env_b
+            echo KAKAO_API_KEY=${{ secrets.KAKAO_API_KEY }} >> .env_b
+            echo NAVER_API_KEY=${{ secrets.NAVER_API_KEY }} >> .env_b
+            echo NAVER_API_SECRET=${{ secrets.NAVER_API_SECRET }} >> .env_b
+            echo RDS_USERNAME=${{ secrets.RDS_USERNAME }} >> .env_b
+            echo RDS_PASSWORD=${{ secrets.RDS_PASSWORD }} >> .env_b
+            echo ${{ secrets.PORT }}:${{ secrets.PORT }} >> .env_b
+                    
+#           백엔드 도커 이미지 pull 및 도커 컴포즈 실행
+            sudo docker-compose up -d

--- a/src/main/java/com/sportsecho/memberProduct/repository/MemberProductRepository.java
+++ b/src/main/java/com/sportsecho/memberProduct/repository/MemberProductRepository.java
@@ -1,14 +1,22 @@
 package com.sportsecho.memberProduct.repository;
 
 import com.sportsecho.memberProduct.entity.MemberProduct;
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberProductRepository extends JpaRepository<MemberProduct, Long> {
 
     Optional<MemberProduct> findByProductIdAndMemberId(Long productId, Long memberId);
 
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("select mp from MemberProduct mp join fetch mp.product p where mp.member.id = :memberId")
+    List<MemberProduct> findByMemberIdJoinProductWithOptLock(@Param("memberId") Long memberId);
 
     List<MemberProduct> findByMemberId(Long id);
 

--- a/src/main/java/com/sportsecho/memberProduct/repository/MemberProductRepository.java
+++ b/src/main/java/com/sportsecho/memberProduct/repository/MemberProductRepository.java
@@ -18,10 +18,6 @@ public interface MemberProductRepository extends JpaRepository<MemberProduct, Lo
     @EntityGraph(value = "graph.MemberProduct", type = EntityGraph.EntityGraphType.FETCH)
     List<MemberProduct> findByMemberId(Long memberId);
 
-    @Lock(LockModeType.OPTIMISTIC)
-    @Query("select mp from MemberProduct mp join fetch mp.product p where mp.member.id = :memberId")
-    List<MemberProduct> findByMemberIdJoinProductWithOptLock(@Param("memberId") Long memberId);
-
     @Modifying
     @Query("DELETE FROM MemberProduct mp WHERE mp.member.id = :memberId")
     void deleteByMemberId(@Param("memberId") Long memberId);

--- a/src/main/java/com/sportsecho/product/dto/ProductRequestDto.java
+++ b/src/main/java/com/sportsecho/product/dto/ProductRequestDto.java
@@ -2,6 +2,7 @@ package com.sportsecho.product.dto;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,13 +14,15 @@ public class ProductRequestDto {
     @NotBlank(message = "상품명을 입력해주세요.")
     @Size(max = 30, message = "제목은 30자 이내로 입력해주세요.")
     private String title;
+
     @NotBlank(message = "상품 설명을 입력해주세요.")
     @Size(max = 100, message = "상품 설명은 100자 이내로 입력해주세요.")
     private String content;
-    @NotBlank(message = "상품 가격을 입력해주세요.")
+
+    @NotNull(message = "상품 가격을 입력해주세요.")
     private int price;
-    @NotBlank(message = "상품 수량을 입력해주세요.")
+
+    @NotNull(message = "상품 수량을 입력해주세요.")
     @Min(value = 0, message = "한정 수량은 0개 이상이어야 합니다.")
     private int quantity;
-
 }

--- a/src/main/java/com/sportsecho/product/entity/Product.java
+++ b/src/main/java/com/sportsecho/product/entity/Product.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Version;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -42,13 +43,16 @@ public class Product extends TimeStamp {
     @Column(name = "quantity", nullable = false)
     private int quantity;
 
+    @Version
+    private Long version;
+
     @OneToMany(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<PurchaseProduct> PurchaseProductList = new ArrayList<>();
 
     @OneToMany(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<MemberProduct> memberProductList = new ArrayList<>();
 
-    @BatchSize(size = 20)
+    @BatchSize(size = 32)
     @OneToMany(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<ProductImage> productImageList = new ArrayList<>();
 

--- a/src/main/java/com/sportsecho/product/entity/Product.java
+++ b/src/main/java/com/sportsecho/product/entity/Product.java
@@ -43,7 +43,9 @@ public class Product extends TimeStamp {
     @Column(name = "quantity", nullable = false)
     private int quantity;
 
-    @Version
+//    @Version
+    //@Version 애너테이션의 정확한 동작 방식을 알아보기
+    //관련 없는 쿼리를 날렸을때 어떤 영향이 발생하는지
     private Long version;
 
     @OneToMany(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/sportsecho/product/entity/Product.java
+++ b/src/main/java/com/sportsecho/product/entity/Product.java
@@ -43,9 +43,7 @@ public class Product extends TimeStamp {
     @Column(name = "quantity", nullable = false)
     private int quantity;
 
-//    @Version
-    //@Version 애너테이션의 정확한 동작 방식을 알아보기
-    //관련 없는 쿼리를 날렸을때 어떤 영향이 발생하는지
+    @Version
     private Long version;
 
     @OneToMany(mappedBy = "product", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/sportsecho/purchase/service/PurchaseServiceImplV1.java
+++ b/src/main/java/com/sportsecho/purchase/service/PurchaseServiceImplV1.java
@@ -37,8 +37,9 @@ public class PurchaseServiceImplV1 implements PurchaseService {
     public PurchaseResponseDto purchase(PurchaseRequestDto requestDto, Member member) {
 
         // 장바구니 목록 찾아오기
-        List<MemberProduct> memberProductList = memberProductRepository.findByMemberId(
-            member.getId());
+        List<MemberProduct> memberProductList = memberProductRepository
+            .findByMemberIdJoinProductWithOptLock(member.getId());
+
         if (memberProductList.isEmpty()) {
             throw new GlobalException(PurchaseErrorCode.EMPTY_CART);
         }

--- a/src/main/java/com/sportsecho/purchase/service/PurchaseServiceImplV1.java
+++ b/src/main/java/com/sportsecho/purchase/service/PurchaseServiceImplV1.java
@@ -38,7 +38,7 @@ public class PurchaseServiceImplV1 implements PurchaseService {
 
         // 장바구니 목록 찾아오기
         List<MemberProduct> memberProductList = memberProductRepository
-            .findByMemberIdJoinProductWithOptLock(member.getId());
+            .findByMemberId(member.getId());
 
         if (memberProductList.isEmpty()) {
             throw new GlobalException(PurchaseErrorCode.EMPTY_CART);

--- a/src/test/java/com/sportsecho/hotdeal/service/PurchaseHotdealTest.java
+++ b/src/test/java/com/sportsecho/hotdeal/service/PurchaseHotdealTest.java
@@ -80,7 +80,7 @@ public class PurchaseHotdealTest implements MemberTest, ProductTest, HotdealTest
             purchaseRepository.deleteAll();
         }
 
-        private Product product = productRepository.save(TEST_PRODUCT);
+        private Product product = productRepository.save(ANOTHER_TEST_PRODUCT);
         private Hotdeal hotdeal = hotdealRepository.save(
             HotdealTestUtil.createHotdeal(TEST_START_DAY, TEST_DUE_DAY, TEST_DEAL_QUANTITY,
                 TEST_SALE, product));

--- a/src/test/java/com/sportsecho/hotdeal/service/PurchaseHotdealTest.java
+++ b/src/test/java/com/sportsecho/hotdeal/service/PurchaseHotdealTest.java
@@ -75,18 +75,31 @@ public class PurchaseHotdealTest implements MemberTest, ProductTest, HotdealTest
     @DisplayName("단일 구매자의 구매 테스트")
     class SinglePurchaseTest {
 
+        private Product product;
+        private Hotdeal hotdeal;
+        private PurchaseHotdealRequestDto requestDto;
+
+        @BeforeEach
+        void setUp() {
+            product = productRepository.save(
+                Product.builder()
+                    .title(TEST_PRODUCT_TITLE)
+                    .content(TEST_PRODUCT_CONTENT)
+                    .price(TEST_PRICE)
+                    .quantity(TEST_QUANTITY)
+                    .build()
+            );
+            hotdeal = hotdealRepository.save(
+                HotdealTestUtil.createHotdeal(TEST_START_DAY, TEST_DUE_DAY, TEST_DEAL_QUANTITY,
+                    TEST_SALE, product));
+            requestDto = HotdealTestUtil.createTestPurchaseHotdealRequestDto(
+                hotdeal.getId(), 3);
+        }
+
         @AfterEach
         void tearDown() {
             purchaseRepository.deleteAll();
         }
-
-        private Product product = productRepository.save(ANOTHER_TEST_PRODUCT);
-        private Hotdeal hotdeal = hotdealRepository.save(
-            HotdealTestUtil.createHotdeal(TEST_START_DAY, TEST_DUE_DAY, TEST_DEAL_QUANTITY,
-                TEST_SALE, product));
-
-        private PurchaseHotdealRequestDto requestDto = HotdealTestUtil.createTestPurchaseHotdealRequestDto(
-            hotdeal.getId(), 3);
 
         @Test
         @DisplayName("성공 - 구매자가 구매한 상품이 구매 목록에 추가되는지 확인")

--- a/src/test/java/com/sportsecho/product/ProductTest.java
+++ b/src/test/java/com/sportsecho/product/ProductTest.java
@@ -15,4 +15,10 @@ public interface ProductTest {
         .price(TEST_PRICE)
         .quantity(TEST_QUANTITY)
         .build();
+    Product ANOTHER_TEST_PRODUCT = Product.builder()
+        .title(TEST_PRODUCT_TITLE)
+        .content(TEST_PRODUCT_CONTENT)
+        .price(TEST_PRICE)
+        .quantity(TEST_QUANTITY)
+        .build();
 }


### PR DESCRIPTION
## 개요
Product Entity OptimisticLock 기능 추가

## 작업사항
- Product Entity @Version 어노테이션 적용

## 변경로직
- ProductRequestDto int형 필드 @NotBlank -> @NotNull로 변경
- ProductImage 연관관계 필드 QueryPlanCache에 맞춰 @BatchSize(20 -> 32)로 변경
- 단일 구매자의 구매 테스트 필드 선언 구조 변경

## 관련이슈
- GithubActions의 성능이 좋지 않아 트랜잭션이 밀려 동시성 문제에 걸리는 버그 발견
- 테스트별로 product 객체를 새로 만들고 할당해 해결